### PR TITLE
wombat status polish

### DIFF
--- a/less/colors.less
+++ b/less/colors.less
@@ -1,3 +1,5 @@
+@transparent: "transparent";
+
 @white-10: rgba(255, 255, 255, 0.1);
 @white-90: rgba(255, 255, 255, 0.9);
 @white-two: #eeeeee;
@@ -17,3 +19,7 @@
 @wombat-green: #7ed321;
 
 @neon-purple: #bc19f5;
+
+@orange-yellow: #ffa300;
+
+@red-dying: #ff0000;

--- a/less/components/game-rankings.less
+++ b/less/components/game-rankings.less
@@ -3,11 +3,11 @@
 .game-ranking-box {
     height: 50%;
 
-    ul {
+    .list-wombat-status {
         list-style-type: none;
         padding: 0;
 
-        li {
+        .wombat-status {
             min-width: 300px;
             height: 30px;
             background-color: @white-10;
@@ -18,27 +18,20 @@
             align-items: center;
 
             .health-bar {
-                width: 30px;
-	        height: 4px;  /* Can be anything */
-	        background: #555;
-                transform: rotate(-90deg);
-            }
-
-            .health-bar[value] {
-                /* Reset the default appearance */
-                -webkit-appearance: none;
-                appearance: none;
-
-                width: 30px;
-                height: 4px;
+                position: relative;
                 margin-left: -13px;
                 margin-right: -9px;
-            }
+                width: 30px;
+	        height: 4px;
+                transform: rotate(-90deg);
 
-            .health-bar[value]::-webkit-progress-value {
-                background-color: @wombat-green;
+                .filling {
+                    display: block;
+                    height: 100%;
+                    position: relative;
+                    overflow: hidden;
+                }
             }
-            
 
             .img-wrapper {  
                 width: 30px;
@@ -56,12 +49,13 @@
             }
 
             .username {
-                padding-left: 80px;
+                position: absolute;
+                padding-left: 200px;
             }
 
             .score {
                 position: absolute;
-                right: 5px;
+                right: 10px;
             }
 
             & > div {
@@ -69,6 +63,10 @@
                 vertical-align: middle;
                 height: 100%;
                 line-height: 30px;
+            }
+
+            &.disabled {
+                opacity: 0.5;
             }
         }
     }

--- a/less/components/game-rankings.less
+++ b/less/components/game-rankings.less
@@ -30,6 +30,20 @@
                     height: 100%;
                     position: relative;
                     overflow: hidden;
+
+                    &.none {
+                        background-color: @transparent;
+                    }
+
+                    &.healthy {
+                        background-color: @wombat-green;
+                    }
+                    &.okay-health {
+                        background-color: @orange-yellow;
+                    }
+                    &.dying {
+                        background-color: @red-dying;
+                    }
                 }
             }
 

--- a/src/cljs/wombats_web_client/components/game_ranking.cljs
+++ b/src/cljs/wombats_web_client/components/game_ranking.cljs
@@ -1,18 +1,30 @@
-(ns wombats-web-client.components.game-ranking)
+(ns wombats-web-client.components.game-ranking
+  (:require [wombats-web-client.constants.colors :refer [wombat-green
+                                                         orange-yellow
+                                                         red-dying
+                                                         transparent]]))
+
+(defn get-health-color [hp]
+  (cond
+   (<= 70 hp 100) wombat-green
+   (<= 30 hp 69) orange-yellow
+   (<= 1 hp 29) red-dying
+   :else transparent))
 
 (defn ranking-box
   [game-id stats]
   (fn []
     [:div {:class-name "game-ranking-box"}
-     [:ul
+     [:ul.list-wombat-status
       (for [{:keys [wombat-name
                     username
                     score
                     hp
                     color]} @stats]
-        ^{:key username} [:li
-                          [:progress.health-bar {:max 100
-                                       :value hp}]
+        ^{:key username} [:li.wombat-status {:class (when (= hp 0) "disabled")}
+                          [:div.health-bar 
+                           [:span.filling {:style {:width (str hp "%")
+                                                   :background-color (get-health-color hp)}}]]
                           [:div.img-wrapper
                            [:img {:src (str "/images/wombat_" color "_right.png")}]]
                           [:div.wombat-name wombat-name]

--- a/src/cljs/wombats_web_client/components/game_ranking.cljs
+++ b/src/cljs/wombats_web_client/components/game_ranking.cljs
@@ -1,15 +1,11 @@
-(ns wombats-web-client.components.game-ranking
-  (:require [wombats-web-client.constants.colors :refer [wombat-green
-                                                         orange-yellow
-                                                         red-dying
-                                                         transparent]]))
+(ns wombats-web-client.components.game-ranking)
 
 (defn get-health-color [hp]
   (cond
-   (<= 70 hp 100) wombat-green
-   (<= 30 hp 69) orange-yellow
-   (<= 1 hp 29) red-dying
-   :else transparent))
+   (<= 70 hp 100) "healthy"
+   (<= 30 hp 69) "okay-health"
+   (<= 1 hp 29) "dying"
+   :else "none"))
 
 (defn ranking-box
   [game-id stats]
@@ -22,9 +18,9 @@
                     hp
                     color]} @stats]
         ^{:key username} [:li.wombat-status {:class (when (= hp 0) "disabled")}
-                          [:div.health-bar 
-                           [:span.filling {:style {:width (str hp "%")
-                                                   :background-color (get-health-color hp)}}]]
+                          [:div.health-bar
+                           [:span.filling {:class (get-health-color hp)
+                                           :style {:width (str hp "%")}}]]
                           [:div.img-wrapper
                            [:img {:src (str "/images/wombat_" color "_right.png")}]]
                           [:div.wombat-name wombat-name]

--- a/src/cljs/wombats_web_client/constants/colors.cljs
+++ b/src/cljs/wombats_web_client/constants/colors.cljs
@@ -8,3 +8,8 @@
                {:color-text "red" :color-hex "#D40000"}
                {:color-text "white" :color-hex "#C9C9C9"}
                {:color-text "yellow" :color-hex "#E1E700"}])
+
+(defonce wombat-green "#7ed321")
+(defonce orange-yellow "#ffa300")
+(defonce red-dying "#ff0000")
+(defonce transparent "transparent")

--- a/src/cljs/wombats_web_client/constants/colors.cljs
+++ b/src/cljs/wombats_web_client/constants/colors.cljs
@@ -8,8 +8,3 @@
                {:color-text "red" :color-hex "#D40000"}
                {:color-text "white" :color-hex "#C9C9C9"}
                {:color-text "yellow" :color-hex "#E1E700"}])
-
-(defonce wombat-green "#7ed321")
-(defonce orange-yellow "#ffa300")
-(defonce red-dying "#ff0000")
-(defonce transparent "transparent")


### PR DESCRIPTION
## PR for Issue #18 

* Polished wombat status by refactoring progress bar styles. `:div` allows for more flexibility than the html5 `:progress`. Inline styles are cleaner for fill color changes.
* Fill changes based on HP value
* Formatting Github Name based on absolute position so that usernames will align in chart.
* UI will not show as defaulted to HP=100% until [issue #232](https://github.com/willowtreeapps/wombats-api/issues/232) in Wombat-API is resolved. 