### PR TITLE
Game Polling

### DIFF
--- a/src/cljs/wombats_web_client/events/games.cljs
+++ b/src/cljs/wombats_web_client/events/games.cljs
@@ -33,6 +33,7 @@
                   :handler on-success
                   :error-handler on-error}))
 
+;; TODO Scaling Issue with Lots of games - only update with games that are new?
 (defn get-open-games []
   (get-pending-open-games
    #(re-frame/dispatch [:open-games %])

--- a/src/cljs/wombats_web_client/events/user.cljs
+++ b/src/cljs/wombats_web_client/events/user.cljs
@@ -159,5 +159,4 @@
                  :on-success      [:update-wombats]
                  :on-failure      [:user-error]}
     :dispatch [:update-user user]
-    :get-open-games nil
     :get-joined-games (user :id)}))

--- a/src/cljs/wombats_web_client/routes.cljs
+++ b/src/cljs/wombats_web_client/routes.cljs
@@ -5,6 +5,7 @@
               [goog.events :as events]
               [goog.history.EventType :as EventType]
               [re-frame.core :as re-frame]
+              [wombats-web-client.events.games :refer [get-open-games]]
               [wombats-web-client.events.user :refer [sign-out-event]]))
 
 (defn hook-browser-navigation! []
@@ -21,6 +22,7 @@
   ;; define routes here
 
   (defroute "/" []
+    (get-open-games)
     (re-frame/dispatch [:set-active-panel :view-games-panel]))
 
   (defroute "/games/:game-id" {game-id :game-id}


### PR DESCRIPTION
## Issue [#156](https://github.com/willowtreeapps/wombats-api/issues/156)

* Removed temp polling button
* Page updates automatically every minute if stationary on the page
* Games Page updates on page load/refresh
* TODO - Update games dispatcher to check for delta additions in return? What if open games are removed?