### PR TITLE
adjust hp if nil

### DIFF
--- a/src/cljs/wombats_web_client/components/game_ranking.cljs
+++ b/src/cljs/wombats_web_client/components/game_ranking.cljs
@@ -7,32 +7,33 @@
    (<= 1 hp 29) "dying"
    :else "none"))
 
-(defn get-adjusted-hp [is-starting?]
-  (if is-starting? 100 0))
+(defn get-adjusted-hp [info]
+  (let [game-status (:status @info)
+        is-starting? (or (= game-status :pending-open) (= game-status :pending-closed))]
+    (if is-starting? 100 0)))
 
+(defn render-wombat-status [info stat]
+  (let [{:keys [wombat-name
+                username
+                score
+                hp
+                color]} stat
+        adjusted-hp-value (if (nil? hp) (get-adjusted-hp info) hp)]
+    ^{:key username} [:li.wombat-status {:class (when (= adjusted-hp-value 0) "disabled")}
+                            [:div.health-bar
+                             [:span.filling {:class (get-health-color adjusted-hp-value)
+                                             :style {:width (str adjusted-hp-value "%")}}]]
+                            [:div.img-wrapper
+                             [:img {:src (str "/images/wombat_" color "_right.png")}]]
+                            [:div.wombat-name wombat-name]
+                            [:div.username username]
+                            [:div.score score]]))
 (defn ranking-box
-  [game-id stats info]
+  [stats info]
   (fn []
-    (let [game-status (:status @info)
-          is-starting? (or (= game-status :pending-open) (= game-status :pending-closed))]
-      [:div {:class-name "game-ranking-box"}
-       [:ul.list-wombat-status
-        (for [{:keys [wombat-name
-                      username
-                      score
-                      hp
-                      color]} @stats]
-          (let [hp-nil? (nil? hp)
-                adjusted-hp-value (if hp-nil? (get-adjusted-hp is-starting?) hp)]
-            ^{:key username} [:li.wombat-status {:class (when (= adjusted-hp-value 0) "disabled")}
-                              [:div.health-bar
-                               [:span.filling {:class (get-health-color adjusted-hp-value)
-                                               :style {:width (str adjusted-hp-value "%")}}]]
-                              [:div.img-wrapper
-                               [:img {:src (str "/images/wombat_" color "_right.png")}]]
-                              [:div.wombat-name wombat-name]
-                              [:div.username username]
-                              [:div.score score]]))]])))
+    [:div {:class-name "game-ranking-box"}
+     [:ul.list-wombat-status
+      (doall (map #(render-wombat-status info %) @stats))]]))
 
 
 

--- a/src/cljs/wombats_web_client/components/game_ranking.cljs
+++ b/src/cljs/wombats_web_client/components/game_ranking.cljs
@@ -7,25 +7,32 @@
    (<= 1 hp 29) "dying"
    :else "none"))
 
+(defn get-adjusted-hp [isStarting?]
+  (if isStarting? 100 0))
+
 (defn ranking-box
-  [game-id stats]
+  [game-id stats info]
   (fn []
-    [:div {:class-name "game-ranking-box"}
-     [:ul.list-wombat-status
-      (for [{:keys [wombat-name
-                    username
-                    score
-                    hp
-                    color]} @stats]
-        ^{:key username} [:li.wombat-status {:class (when (= hp 0) "disabled")}
-                          [:div.health-bar
-                           [:span.filling {:class (get-health-color hp)
-                                           :style {:width (str hp "%")}}]]
-                          [:div.img-wrapper
-                           [:img {:src (str "/images/wombat_" color "_right.png")}]]
-                          [:div.wombat-name wombat-name]
-                          [:div.username username]
-                          [:div.score score]])]]))
+    (let [game-status (:status @info)
+          isStarting? (or (= game-status :pending-open) (= game-status :pending-closed))]
+      [:div {:class-name "game-ranking-box"}
+       [:ul.list-wombat-status
+        (for [{:keys [wombat-name
+                      username
+                      score
+                      hp
+                      color]} @stats]
+          (let [hpNil? (nil? hp)
+                adjusted-hp-value (if hpNil? (get-adjusted-hp isStarting?) hp)]
+            ^{:key username} [:li.wombat-status {:class (when (= adjusted-hp-value 0) "disabled")}
+                              [:div.health-bar
+                               [:span.filling {:class (get-health-color adjusted-hp-value)
+                                               :style {:width (str adjusted-hp-value "%")}}]]
+                              [:div.img-wrapper
+                               [:img {:src (str "/images/wombat_" color "_right.png")}]]
+                              [:div.wombat-name wombat-name]
+                              [:div.username username]
+                              [:div.score score]]))]])))
 
 
 

--- a/src/cljs/wombats_web_client/components/game_ranking.cljs
+++ b/src/cljs/wombats_web_client/components/game_ranking.cljs
@@ -7,14 +7,14 @@
    (<= 1 hp 29) "dying"
    :else "none"))
 
-(defn get-adjusted-hp [isStarting?]
-  (if isStarting? 100 0))
+(defn get-adjusted-hp [is-starting?]
+  (if is-starting? 100 0))
 
 (defn ranking-box
   [game-id stats info]
   (fn []
     (let [game-status (:status @info)
-          isStarting? (or (= game-status :pending-open) (= game-status :pending-closed))]
+          is-starting? (or (= game-status :pending-open) (= game-status :pending-closed))]
       [:div {:class-name "game-ranking-box"}
        [:ul.list-wombat-status
         (for [{:keys [wombat-name
@@ -22,8 +22,8 @@
                       score
                       hp
                       color]} @stats]
-          (let [hpNil? (nil? hp)
-                adjusted-hp-value (if hpNil? (get-adjusted-hp isStarting?) hp)]
+          (let [hp-nil? (nil? hp)
+                adjusted-hp-value (if hp-nil? (get-adjusted-hp is-starting?) hp)]
             ^{:key username} [:li.wombat-status {:class (when (= adjusted-hp-value 0) "disabled")}
                               [:div.health-bar
                                [:span.filling {:class (get-health-color adjusted-hp-value)

--- a/src/cljs/wombats_web_client/panels/game-play.cljs
+++ b/src/cljs/wombats_web_client/panels/game-play.cljs
@@ -84,7 +84,7 @@
       [game-play-title info]
       [game-play-subtitle info]
       [max-players info stats]
-      [ranking-box @game-id stats]]
+      [ranking-box @game-id stats info]]
 
      [:div.chat-panel
       [chat-title]

--- a/src/cljs/wombats_web_client/panels/game-play.cljs
+++ b/src/cljs/wombats_web_client/panels/game-play.cljs
@@ -84,7 +84,7 @@
       [game-play-title info]
       [game-play-subtitle info]
       [max-players info stats]
-      [ranking-box @game-id stats info]]
+      [ranking-box stats info]]
 
      [:div.chat-panel
       [chat-title]


### PR DESCRIPTION
Fixes issue #232 

The HP of wombats is `nil` if the game hasn't started or if the wombat has died. I'm adjusting the HP to either 100 or 0 depending on the scenario.