### PR TITLE
Prevent redirect into lobby on-click of the join btn

### DIFF
--- a/src/cljs/wombats_web_client/components/cards/game.cljs
+++ b/src/cljs/wombats_web_client/components/cards/game.cljs
@@ -4,7 +4,8 @@
             [wombats-web-client.components.modals.join-wombat-modal :refer [join-wombat-modal]]))
 
 (defn open-join-game-modal-fn [game-id occupied-colors]
-  (fn []
+  (fn [e]
+    (.preventDefault e)
     (re-frame/dispatch [:set-modal {:fn #(join-wombat-modal game-id occupied-colors)
                                     :show-overlay? true}])))
 


### PR DESCRIPTION
### Problem 

The click event on the game card is propagating to the redirect function when you click on the join btn.

### Solution

`e.preventDefault` when clicking on that button.