### PR TITLE
User Navbar Roles

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -11,6 +11,7 @@
 @import "panels/account.less";
 @import "panels/game-play.less";
 @import "panels/games.less";
+@import "panels/page-not-found.less";
 
 // COMPONENTS
 @import "components/cards/game-card.less";

--- a/less/panels/page-not-found.less
+++ b/less/panels/page-not-found.less
@@ -1,0 +1,11 @@
+@import '../colors.less';
+
+.page-not-found {
+    color: @white;
+    letter-spacing: 2px;
+    font-weight: 600;
+    font-size: 16px;
+    margin-top: 300px;
+    width: 100%;
+    text-align: center;
+}

--- a/src/cljs/wombats_web_client/components/navbar.cljs
+++ b/src/cljs/wombats_web_client/components/navbar.cljs
@@ -2,7 +2,8 @@
   (:require [re-frame.core :as re-frame]
             [reagent.core :as reagent]
             [wombats-web-client.constants.urls :refer [github-signin-url
-                                                       panel-router-map]]))
+                                                       panel-router-map]]
+            [wombats-web-client.utils.auth :refer [user-is-coordinator?]]))
 
 (defn login []
   [:a {:href github-signin-url} "Login"])
@@ -17,7 +18,14 @@
    [:a {:class (if (= current id) "active") 
         :href link} title]])
 
-(defn nav-links 
+(defn coordinator-links [selected]
+  [nav-link {:id "config"
+             :class "regular-link"
+             :link "#/config"
+             :title "CONFIG"
+             :current selected}])
+
+(defn nav-links
   [user selected]
   [:ul.navbar
    [nav-link {:id "games"
@@ -25,12 +33,7 @@
               :link "#/"
               :title "GAMES"
               :current selected}]
-   [nav-link {:id "config"
-              :class "regular-link"
-              :link "#/config"
-              :title "CONFIG"
-              :current selected}]
-
+   (when (user-is-coordinator?) [coordinator-links selected])
    (if-not user
      [:li {:class "regular-link account"}
       [:a {:href github-signin-url} "LOGIN"]]

--- a/src/cljs/wombats_web_client/panels/page-not-found.cljs
+++ b/src/cljs/wombats_web_client/panels/page-not-found.cljs
@@ -1,0 +1,4 @@
+(ns wombats-web-client.panels.page-not-found)
+
+(defn page-not-found []
+  [:div.page-not-found "The page you are looking for cannot be found."])

--- a/src/cljs/wombats_web_client/routes.cljs
+++ b/src/cljs/wombats_web_client/routes.cljs
@@ -5,7 +5,8 @@
               [goog.events :as events]
               [goog.history.EventType :as EventType]
               [re-frame.core :as re-frame]
-              [wombats-web-client.events.user :refer [sign-out-event]]))
+              [wombats-web-client.events.user :refer [sign-out-event]]
+              [wombats-web-client.utils.auth :refer [user-is-coordinator?]]))
 
 (defn hook-browser-navigation! []
   (doto (History.)
@@ -28,7 +29,9 @@
     (re-frame/dispatch [:set-active-panel :game-play-panel]))
 
   (defroute "/config" []
-    (re-frame/dispatch [:set-active-panel :config-panel]))
+    (if (user-is-coordinator?)
+      (re-frame/dispatch [:set-active-panel :config-panel])
+      (re-frame/dispatch [:set-active-panel :page-not-found-panel])))
 
   (defroute "/account" []
     (re-frame/dispatch [:set-active-panel :account-panel]))

--- a/src/cljs/wombats_web_client/utils/auth.cljs
+++ b/src/cljs/wombats_web_client/utils/auth.cljs
@@ -15,3 +15,15 @@
 
 (defn get-current-user-id []
   (:user/id @(re-frame/subscribe [:current-user])))
+
+(defn get-current-user-roles []
+  (:user/roles @(re-frame/subscribe [:current-user])))
+
+(defn user-is-coordinator? []
+  (let [roles (get-current-user-roles)]
+    (reduce (fn [is-admin? role]
+              (let [role-name (:db/ident role)]
+                (or
+                 is-admin?
+                 (= role-name :user.roles/admin)
+                 (= role-name :user.roles/coordinator)))) false roles)))

--- a/src/cljs/wombats_web_client/views.cljs
+++ b/src/cljs/wombats_web_client/views.cljs
@@ -7,7 +7,8 @@
               ;; Panels
               [wombats-web-client.panels.games :as view-games-panel]
               [wombats-web-client.panels.account :as account-panel]
-              [wombats-web-client.panels.game-play :as game-play-panel]))
+              [wombats-web-client.panels.game-play :as game-play-panel]
+              [wombats-web-client.panels.page-not-found :as page-not-found-panel]))
 
 ;; mainutil
 
@@ -16,6 +17,7 @@
     :view-games-panel [view-games-panel/games]
     :account-panel [account-panel/account]
     :game-play-panel [game-play-panel/game-play]
+    :page-not-found-panel [page-not-found-panel/page-not-found]
     [:div]))
 
 (defn show-panel [panel-name]


### PR DESCRIPTION
# Fixes #116 .

## PR Status

**READY**

## Changes proposed in the pull request:
- Only show Config navbar link if Coordinator or Admin
- If routed to `/#/config`, check for user role to access
- If not admin/coordinator and navigating to a url that requires that role, show new page not found panel.

## Breaking changes?
- None
