### PR TITLE
Feature/inline errors

### DIFF
--- a/less/components/inline-error.less
+++ b/less/components/inline-error.less
@@ -1,0 +1,9 @@
+
+.inline-error(@padding-left: 30px) {
+    .inline-error {
+        text-align: left;
+        padding-left: @padding-left;
+        font-size: 12px;
+        color: @error-red;
+    }
+}

--- a/less/components/modals/join-wombat-modal.less
+++ b/less/components/modals/join-wombat-modal.less
@@ -1,5 +1,6 @@
 @import "../../colors.less";
 @import "../../objects/label.less";
+@import "../../components/inline-error.less";
 
 .modal-container {
     .join-wombat-modal {
@@ -59,13 +60,7 @@
                 }
             }
 
-            .inline-error {
-                text-align: left;
-                font-size: 12px;
-                color: @error-red;
-                position: absolute;
-                top: calc(@form-input-height ~"+" @form-input-margin-bottom);
-            }
+            .inline-error(@padding-left: 0);
 
             .dropdown-wrapper {
                 display: block;
@@ -96,14 +91,7 @@
             margin-bottom: 30px;
             
             .label;
-
-            
-            .inline-error {
-                text-align: left;
-                font-size: 12px;
-                color: @error-red;
-                top: calc(@form-input-height ~"+" @form-input-margin-bottom);
-            }
+            .inline-error(@padding-left: 0);
 
             .colors {
                 display: flex;

--- a/less/components/modals/join-wombat-modal.less
+++ b/less/components/modals/join-wombat-modal.less
@@ -6,7 +6,7 @@
         .private-game-msg {
             width: 310px;
             margin: 0 auto;
-            margin-bottom: 40px;
+            margin-bottom: 20px;
         }
 
         .private-game-container {
@@ -17,6 +17,7 @@
             width: 310px;
             margin: 0 auto;
             margin-bottom: 30px;
+            position: relative;
 
             .label;
 
@@ -33,6 +34,11 @@
                 &.unselected {
                     background-color: @white;
                 }
+
+                &.field-error {
+                    border: 1px solid @error-red;
+                }
+
 
                 .text {
                     color: @black;
@@ -52,6 +58,13 @@
                 }
             }
 
+            .inline-error {
+                text-align: left;
+                font-size: 12px;
+                color: @error-red;
+                position: absolute;
+                top: calc(@form-input-height ~"+" @form-input-margin-bottom);
+            }
             .dropdown-wrapper {
                 display: block;
                 position: absolute;
@@ -124,7 +137,7 @@
                         padding: 10px;
                         opacity: 1;
                         display: none;
-                        
+
                         &.display {
                             display: flex;
                         }

--- a/less/components/modals/join-wombat-modal.less
+++ b/less/components/modals/join-wombat-modal.less
@@ -3,14 +3,15 @@
 
 .modal-container {
     .join-wombat-modal {
-        .private-game-msg {
-            width: 310px;
-            margin: 0 auto;
-            margin-bottom: 20px;
-        }
-
         .private-game-container {
             .label(@padding-left: 30px);
+
+            .private-game-msg {
+                width: 310px;
+                margin: 0 auto;
+                margin-bottom: 20px;
+                font-size: 14px;
+            }
         }
 
         .select-wombat {
@@ -65,6 +66,7 @@
                 position: absolute;
                 top: calc(@form-input-height ~"+" @form-input-margin-bottom);
             }
+
             .dropdown-wrapper {
                 display: block;
                 position: absolute;
@@ -92,8 +94,16 @@
             width: 310px;
             margin: 0 auto;
             margin-bottom: 30px;
-
+            
             .label;
+
+            
+            .inline-error {
+                text-align: left;
+                font-size: 12px;
+                color: @error-red;
+                top: calc(@form-input-height ~"+" @form-input-margin-bottom);
+            }
 
             .colors {
                 display: flex;

--- a/less/components/modals/join-wombat-modal.less
+++ b/less/components/modals/join-wombat-modal.less
@@ -1,4 +1,5 @@
 @import "../../colors.less";
+@import "../../objects/label.less";
 
 .modal-container {
     .join-wombat-modal {
@@ -8,15 +9,16 @@
             margin-bottom: 40px;
         }
 
+        .private-game-container {
+            .label(@padding-left: 30px);
+        }
+
         .select-wombat {
             width: 310px;
             margin: 0 auto;
-            margin-bottom: 40px;
+            margin-bottom: 30px;
 
-            .select-wombat-label {
-                padding-left: 0;
-                margin-bottom: 10px;
-            }
+            .label;
 
             .placeholder {
                 color: @black;
@@ -74,22 +76,22 @@
         }
 
         .select-color {
-            .label {
-                margin-bottom: 10px;
-            }
+            width: 310px;
+            margin: 0 auto;
+            margin-bottom: 30px;
+
+            .label;
+
             .colors {
                 display: flex;
                 flex-flow: row wrap;
-                width: 310px;
-                margin: 0 auto;
-                margin-bottom: 40px;
                 justify-content: space-between;
 
                 .wombat-img-wrapper {
                     cursor: pointer;
-                    margin-bottom: 5px;
                     display: inline-block;
-                    width: 25%;
+                    width: 60px;
+                    margin: 5px;
 
                     .disabled {
                         display: none;
@@ -122,7 +124,7 @@
                         padding: 10px;
                         opacity: 1;
                         display: none;
-                       
+                        
                         &.display {
                             display: flex;
                         }

--- a/less/components/text-input.less
+++ b/less/components/text-input.less
@@ -1,0 +1,28 @@
+@import "../colors.less";
+@import "../objects/label.less";
+@import "../components/inline-error";
+
+@text-input-padding-left: 30px;
+@text-input-height: 45px;
+@text-input-margin-bottom: 30px;
+
+.text-input-wrapper {
+    text-align: center;
+    margin-bottom: @text-input-margin-bottom;
+
+    .label(@padding-left: @text-input-padding-left);
+
+    .input {
+        border-style: none;
+        width: 305px;
+        height: @text-input-height;
+        font-size: 20px;
+        padding-left: 5px;
+        
+        &.field-error {
+            border: 1px solid @error-red;
+        }
+    }
+
+    .inline-error;
+}

--- a/less/forms.less
+++ b/less/forms.less
@@ -1,25 +1,40 @@
 @import "colors.less";
 @import "objects/button.less";
+@import "objects/label.less";
 
-.label {
-    text-align: left;
-    font-size: 12px;
-    color: @warm-grey;
-    display: block;
-    padding-left: 30px;
-}
+@form-input-padding-left: 30px;
+@form-input-height: 45px;
+@form-input-margin-bottom: 30px;
 
 .text-input-wrapper {
     text-align: center;
+    position: relative;
+
+    .label(@form-input-padding-left);
 
     .input {
         border-style: none;
         width: 305px;
-        height: 45px;
+        height: @form-input-height;
         font-size: 20px;
         padding-left: 5px;
-        margin-bottom: 30px;
+        margin-bottom: @form-input-margin-bottom;
+
+        
+        &.field-error {
+            border: 1px solid @error-red;
+        }
     }
+
+   /* 
+   .inline-error {
+        padding-left: @form-input-padding-left;
+        text-align: left;
+        font-size: 12px;
+        color: @error-red;
+        position: absolute;
+        top: calc(@form-input-height ~"+" @form-input-margin-bottom ~"-" 5px);
+    }*/
 }
 
 .modal-button {

--- a/less/forms.less
+++ b/less/forms.less
@@ -1,40 +1,4 @@
-@import "colors.less";
 @import "objects/button.less";
-@import "objects/label.less";
-
-@form-input-padding-left: 30px;
-@form-input-height: 45px;
-@form-input-margin-bottom: 30px;
-
-.text-input-wrapper {
-    text-align: center;
-    position: relative;
-
-    .label(@padding-left: @form-input-padding-left);
-
-    .input {
-        border-style: none;
-        width: 305px;
-        height: @form-input-height;
-        font-size: 20px;
-        padding-left: 5px;
-        margin-bottom: @form-input-margin-bottom;
-
-        
-        &.field-error {
-            border: 1px solid @error-red;
-        }
-    }
-    
-    .inline-error {
-        text-align: left;
-        padding-left: @form-input-padding-left;
-        font-size: 12px;
-        color: @error-red;
-        position: absolute;
-        top: calc(@form-input-height ~"+" @form-input-margin-bottom);
-    }
-}
 
 .modal-button {
     .simple-button;

--- a/less/forms.less
+++ b/less/forms.less
@@ -25,16 +25,14 @@
             border: 1px solid @error-red;
         }
     }
-
-   /* 
-   .inline-error {
-        padding-left: @form-input-padding-left;
+    
+    .inline-error {
         text-align: left;
         font-size: 12px;
         color: @error-red;
         position: absolute;
         top: calc(@form-input-height ~"+" @form-input-margin-bottom ~"-" 5px);
-    }*/
+    }
 }
 
 .modal-button {

--- a/less/forms.less
+++ b/less/forms.less
@@ -10,7 +10,7 @@
     text-align: center;
     position: relative;
 
-    .label(@form-input-padding-left);
+    .label(@padding-left: @form-input-padding-left);
 
     .input {
         border-style: none;
@@ -28,10 +28,11 @@
     
     .inline-error {
         text-align: left;
+        padding-left: @form-input-padding-left;
         font-size: 12px;
         color: @error-red;
         position: absolute;
-        top: calc(@form-input-height ~"+" @form-input-margin-bottom ~"-" 5px);
+        top: calc(@form-input-height ~"+" @form-input-margin-bottom);
     }
 }
 

--- a/less/main.less
+++ b/less/main.less
@@ -6,6 +6,7 @@
 
 // OBJECTS
 @import "objects/button.less";
+@import "objects/label.less";
 
 // PANELS
 @import "panels/account.less";

--- a/less/main.less
+++ b/less/main.less
@@ -24,7 +24,9 @@
 @import "components/modals/winner-modal.less";
 @import "components/add-button.less";
 @import "components/chat-box.less";
+@import "components/inline-error.less";
 @import "components/navbar.less";
+@import "components/text-input.less";
 @import "components/game-rankings.less";
 
 

--- a/less/objects/label.less
+++ b/less/objects/label.less
@@ -1,10 +1,14 @@
 
 @import "../colors.less";
 
-.label(@padding-left: 0px) {
-    text-align: left;
-    font-size: 12px;
-    color: @warm-grey;
-    display: block;
-    padding-left: @padding-left;
+.label(@padding-left: 0, @margin-bottom: 5px) {
+    .label {
+        display: block important!;
+        text-align: left;
+        font-size: 12px;
+        color: @warm-grey;
+        display: block;
+        padding-left: @padding-left;
+        margin-bottom: @margin-bottom;
+    }
 }

--- a/less/objects/label.less
+++ b/less/objects/label.less
@@ -1,0 +1,10 @@
+
+@import "../colors.less";
+
+.label(@padding-left: 0px) {
+    text-align: left;
+    font-size: 12px;
+    color: @warm-grey;
+    display: block;
+    padding-left: @padding-left;
+}

--- a/src/cljs/wombats_web_client/components/inline-error.cljs
+++ b/src/cljs/wombats_web_client/components/inline-error.cljs
@@ -1,0 +1,5 @@
+(ns wombats-web-client.components.inline-error)
+
+(defn inline-error [value]
+  (when value
+    [:div.inline-error value]))

--- a/src/cljs/wombats_web_client/components/modals/add-wombat-modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/add-wombat-modal.cljs
@@ -3,6 +3,7 @@
             [reagent.core :as reagent]
             [wombats-web-client.components.text-input :refer [text-input-with-label]]
             [wombats-web-client.events.user :refer [create-new-wombat]]
+            [wombats-web-client.utils.errors :refer [required-field-error]]
             [wombats-web-client.utils.forms :refer [cancel-modal-input
                                                     submit-modal-input]]))
 
@@ -18,12 +19,12 @@
         url (str username "/" 
                  wombat-repo-name "/contents/" 
                  wombat-file-path)]
-    (when (nil? wombat-name)
-      (swap! cmpnt-state assoc :wombat-name-error "This field is required."))
-    (when (nil? wombat-repo-name)
-      (swap! cmpnt-state assoc :wombat-repo-name-error "This field is required."))
-    (when (nil? wombat-file-path)
-      (swap! cmpnt-state assoc :wombat-file-path-error "This field is required."))
+    (when (clojure.string/blank? wombat-name)
+      (swap! cmpnt-state assoc :wombat-name-error required-field-error))
+    (when (clojure.string/blank? wombat-repo-name)
+      (swap! cmpnt-state assoc :wombat-repo-name-error required-field-error))
+    (when (clojure.string/blank? wombat-file-path)
+      (swap! cmpnt-state assoc :wombat-file-path-error required-field-error))
 
     (when (and wombat-name wombat-repo-name wombat-file-path)
       (create-new-wombat wombat-name url #(callback-success cmpnt-state)))))

--- a/src/cljs/wombats_web_client/components/modals/add-wombat-modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/add-wombat-modal.cljs
@@ -14,6 +14,9 @@
   (let [cmpnt-state (reagent/atom {:wombat-name nil
                                    :wombat-repo-name nil
                                    :wombat-file-path nil
+                                   :wombat-name-error nil
+                                   :wombat-repo-name-error nil
+                                   :wombat-file-path-error nil
                                    :error nil})
         modal-error (re-frame/subscribe [:modal-error])
         current-user (re-frame/subscribe [:current-user])]

--- a/src/cljs/wombats_web_client/components/modals/add-wombat-modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/add-wombat-modal.cljs
@@ -10,6 +10,23 @@
   (re-frame/dispatch [:update-modal-error nil])
   (re-frame/dispatch [:set-modal nil]))
 
+(defn on-submit-form-valid? [cmpnt-state username]
+  (let [{:keys [wombat-name
+                wombat-repo-name
+                wombat-file-path]} @cmpnt-state
+        url (str username "/" 
+                 wombat-repo-name "/contents/" 
+                 wombat-file-path)]
+    (when (nil? wombat-name)
+      (swap! cmpnt-state assoc :wombat-name-error "This field is required."))
+    (when (nil? wombat-repo-name)
+      (swap! cmpnt-state assoc :wombat-repo-name-error "This field is required."))
+    (when (nil? wombat-file-path)
+      (swap! cmpnt-state assoc :wombat-file-path-error "This field is required."))
+
+    (when (and wombat-name wombat-repo-name wombat-file-path)
+      (create-new-wombat wombat-name url #(callback-success cmpnt-state)))))
+
 (defn add-wombat-modal []
   (let [cmpnt-state (reagent/atom {:wombat-name nil
                                    :wombat-repo-name nil
@@ -45,11 +62,4 @@
              [cancel-modal-input]
              [:input.modal-button {:type "button"
                                    :value "ADD"
-                                   :on-click (fn []
-                                               (let [url (str username "/" 
-                                                              wombat-repo-name "/contents/" 
-                                                              wombat-file-path)]
-                                                 (create-new-wombat
-                                                  wombat-name
-                                                  url
-                                                  #(callback-success cmpnt-state))))}]]]]))})))
+                                   :on-click #(on-submit-form-valid? cmpnt-state username)}]]]]))})))

--- a/src/cljs/wombats_web_client/components/modals/add-wombat-modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/add-wombat-modal.cljs
@@ -1,9 +1,10 @@
 (ns wombats-web-client.components.modals.add-wombat-modal
   (:require [re-frame.core :as re-frame]
             [reagent.core :as reagent]
+            [wombats-web-client.components.text-input :refer [text-input-with-label]]
             [wombats-web-client.events.user :refer [create-new-wombat]]
-            [wombats-web-client.utils.forms :refer [text-input-with-label
-                                                    cancel-modal-input]]))
+            [wombats-web-client.utils.forms :refer [cancel-modal-input
+                                                    submit-modal-input]]))
 
 (defn callback-success [state]
   "closes modal on success"
@@ -60,6 +61,4 @@
                                     :state cmpnt-state}]
             [:div.action-buttons
              [cancel-modal-input]
-             [:input.modal-button {:type "button"
-                                   :value "ADD"
-                                   :on-click #(on-submit-form-valid? cmpnt-state username)}]]]]))})))
+             [submit-modal-input "ADD" #(on-submit-form-valid? cmpnt-state username)]]]]))})))

--- a/src/cljs/wombats_web_client/components/modals/game-full-modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/game-full-modal.cljs
@@ -1,7 +1,12 @@
 (ns wombats-web-client.components.modals.game-full-modal
-  (:require [re-frame.core :as re-frame]))
+  (:require [re-frame.core :as re-frame]
+            [wombats-web-client.events.games :refer [get-all-games]]))
 
 (defonce full-msg "This game is aready full. Please try joining another game.")
+
+(defn close-modal []
+  (get-all-games)
+  (re-frame/dispatch [:set-modal nil]))
 
 (defn game-full-modal []
   (fn []
@@ -9,4 +14,4 @@
      [:div.title "GAME FULL"]
      [:div.desc full-msg]
      [:div.action-buttons
-      [:button.simple-button {:on-click #(re-frame/dispatch [:set-modal nil])} "OKAY"]]]))
+      [:button.simple-button {:on-click close-modal} "OKAY"]]]))

--- a/src/cljs/wombats_web_client/components/modals/join-wombat-modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/join-wombat-modal.cljs
@@ -19,7 +19,8 @@
                               :wombat-name nil
                               :wombat-id nil
                               :wombat-color nil
-                              :password ""})
+                              :password ""
+                              :password-error nil})
 
 (def callback-success (fn [game-id wombat-id wombat-color password]
                         "closes modal on success"
@@ -97,11 +98,10 @@
   [game cmpnt-state]
   [:div.private-game-container
    [:p.private-game-msg "This is a private game. Please enter the password to join."]
-   [:label.label "Password"]
-   [:div.text-input-wrapper
-    [:input.input {:type "password"
-                   :value (:password @cmpnt-state)
-                   :on-change #(swap! cmpnt-state assoc :password (-> % .-target .-value))}]]])
+   [text-input-with-label {:name "password"
+                           :label "Password"
+                           :state cmpnt-state
+                           :is-password true}]])
 
 (defn join-wombat-modal [game-id]
   (let [modal-error (re-frame/subscribe [:modal-error])

--- a/src/cljs/wombats_web_client/components/modals/join-wombat-modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/join-wombat-modal.cljs
@@ -33,8 +33,11 @@
 
 
 (def callback-error (fn [error cmpnt-state]
+                      (print error)
                       (let [error-code (:code (:response error))
                             is-game-full? (= error-code 101001)]
+
+                        (print error-code)
                         (when is-game-full?
                           (re-frame/dispatch [:set-modal {:fn #(game-full-modal)
                                                           :show-overlay? true}]))

--- a/src/cljs/wombats_web_client/components/modals/join-wombat-modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/join-wombat-modal.cljs
@@ -6,7 +6,8 @@
             [wombats-web-client.events.games :refer [join-open-game
                                                      get-open-games
                                                      get-all-games]]
-            [wombats-web-client.utils.forms :refer [text-input-with-label
+            [wombats-web-client.components.text-input :refer [text-input-with-label]]
+            [wombats-web-client.utils.forms :refer [submit-modal-input
                                                     cancel-modal-input]]
             [wombats-web-client.utils.games :refer [get-occupied-colors]]
             [wombats-web-client.constants.colors :refer [colors-8]]
@@ -126,7 +127,6 @@
                            :is-password true}]])
 
 (defn correct-privacy-settings [is-private password-error]
-  (print (true? password-error))
   (cond 
    is-private (not (true? password-error)) ;; if it's private and there's no error, can submit
    (not is-private) true)) ;; if the game isn't private, password state is irrelevant
@@ -181,8 +181,6 @@
            [select-wombat-color cmpnt-state wombat-color occupied-colors]
            [:div.action-buttons
             [cancel-modal-input]
-            [:input.modal-button {:type "button"
-                                  :value "JOIN"
-                                  :on-click #(on-submit-form-valid? {:game-id game-id
+            [submit-modal-input "JOIN" #(on-submit-form-valid? {:game-id game-id
                                                                     :is-private is-private
-                                                                    :cmpnt-state cmpnt-state})}]]]))})))
+                                                                    :cmpnt-state cmpnt-state})]]]))})))

--- a/src/cljs/wombats_web_client/components/modals/join-wombat-modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/join-wombat-modal.cljs
@@ -10,6 +10,8 @@
             [wombats-web-client.utils.forms :refer [submit-modal-input
                                                     cancel-modal-input]]
             [wombats-web-client.utils.games :refer [get-occupied-colors]]
+            [wombats-web-client.utils.errors :refer [required-field-error
+                                                     wombat-color-missing]]
             [wombats-web-client.constants.colors :refer [colors-8]]
             [wombats-web-client.utils.functions :refer [in?]]
             [wombats-web-client.routes :refer [history]]))
@@ -55,7 +57,7 @@
 (defn on-select-click [cmpnt-state]
   (let [wombat-name-missing (nil? (:wombat-name @cmpnt-state))
         show-dropdown (:show-dropdown @cmpnt-state)
-        error-state (if wombat-name-missing "This field is required" nil)]
+        error-state (when wombat-name-missing required-field-error)]
     (when show-dropdown
        (swap! cmpnt-state assoc :wombat-name-error error-state))
 
@@ -140,11 +142,14 @@
                 password
                 password-error]} @cmpnt-state]
 
-    (when  (nil? wombat-color) (swap! cmpnt-state assoc :wombat-color-error "Please select a color for your wombat."))
+    (when  (nil? wombat-color) 
+      (swap! cmpnt-state assoc :wombat-color-error wombat-color-missing))
 
-    (when (nil? wombat-name) (swap! cmpnt-state assoc :wombat-name-error "This field is required."))
+    (when (nil? wombat-name)
+      (swap! cmpnt-state assoc :wombat-name-error required-field-error))
      
-    (when (and is-private (clojure.string/blank? password)) (swap! cmpnt-state assoc :password-error "This field is required."))
+    (when (and is-private (clojure.string/blank? password)) 
+      (swap! cmpnt-state assoc :password-error required-field-error))
 
     (when (and wombat-name wombat-color (correct-privacy-settings is-private password-error))
       (join-open-game game-id
@@ -152,9 +157,9 @@
                       wombat-color
                       password
                       #(callback-success game-id
-                                   wombat-id
-                                   wombat-color
-                                   password)
+                                         wombat-id
+                                         wombat-color
+                                         password)
                       #(callback-error % cmpnt-state)))))
 
 (defn join-wombat-modal [game-id]

--- a/src/cljs/wombats_web_client/components/text-input.cljs
+++ b/src/cljs/wombats_web_client/components/text-input.cljs
@@ -1,0 +1,31 @@
+(ns wombats-web-client.components.text-input
+  (:require [re-frame.core :as re-frame]
+            [wombats-web-client.utils.forms :refer [get-value]]
+            [wombats-web-client.utils.errors :refer [required-field-error]]
+            [wombats-web-client.components.inline-error :refer [inline-error]]))
+
+
+(defn check-for-valid-text-content [state error-key value]
+  (if (clojure.string/blank? value)
+    (swap! state assoc error-key required-field-error)
+    (swap! state assoc error-key nil)))
+
+(defn on-text-change [state key error-key value]
+  (swap! state assoc error-key nil key value))
+
+;; name must match local component state key
+(defn text-input-with-label
+  [{:keys [name label state is-password]}]
+  (let [key (keyword name)
+        error-key (keyword (str name "-error"))
+        val (get @state key)
+        error-val (get @state error-key)]
+    [:div.text-input-wrapper
+     [:label.label {:for name} label]
+     [:input.input {:class (when error-val "field-error")
+                    :type (if is-password "password" "text")
+                    :name name
+                    :value (when val val)
+                    :on-blur #(check-for-valid-text-content state error-key (get-value %))
+                    :on-change #(on-text-change state key error-key (get-value %))}]
+     [inline-error error-val]]))

--- a/src/cljs/wombats_web_client/utils/errors.cljs
+++ b/src/cljs/wombats_web_client/utils/errors.cljs
@@ -1,0 +1,3 @@
+(ns wombats-web-client.utils.errors)
+
+(defonce required-field-error "This field is required.")

--- a/src/cljs/wombats_web_client/utils/errors.cljs
+++ b/src/cljs/wombats_web_client/utils/errors.cljs
@@ -1,3 +1,4 @@
 (ns wombats-web-client.utils.errors)
 
 (defonce required-field-error "This field is required.")
+(defonce wombat-color-missing "Please select a color for your wombat.")

--- a/src/cljs/wombats_web_client/utils/forms.cljs
+++ b/src/cljs/wombats_web_client/utils/forms.cljs
@@ -1,38 +1,16 @@
 (ns wombats-web-client.utils.forms
   (:require [re-frame.core :as re-frame]))
 
-
 (defn get-value [element]
   (-> element .-target .-value))
 
-(defn check-for-valid-content [state error-key value]
-  (if (clojure.string/blank? value)
-    (swap! state assoc error-key "This field is required")
-    (swap! state assoc error-key nil)))
-
-(defn on-text-change [state key error-key value]
-  (swap! state assoc error-key nil key value))
-
-;; name must match local component state key
-(defn text-input-with-label
-  [{:keys [name label state is-password]}]
-  (let [key (keyword name)
-        error-key (keyword (str name "-error"))
-        val (get @state key)
-        error-val (get @state error-key)]
-    [:div.text-input-wrapper
-     [:label.label {:for name} label]
-     [:input.input {:class (when error-val "field-error")
-                    :type (if is-password "password" "text")
-                    :name name
-                    :value (when val val)
-                    :on-blur #(check-for-valid-content state error-key (get-value %))
-                    :on-change #(on-text-change state key error-key (get-value %))}]
-     (when error-val
-       [:div.inline-error error-val])]))
-
 (defn cancel-modal-input []
   [:input.modal-button {:type "button"
-                               :value "CANCEL"
+                        :value "CANCEL"
                         :on-click (fn []
                                     (re-frame/dispatch [:set-modal nil]))}])
+
+(defn submit-modal-input [submit-value on-click-fn]
+  [:input.modal-button {:type "button"
+                        :value submit-value
+                        :on-click on-click-fn}])

--- a/src/cljs/wombats_web_client/utils/forms.cljs
+++ b/src/cljs/wombats_web_client/utils/forms.cljs
@@ -7,8 +7,11 @@
 
 (defn check-for-valid-content [state error-key value]
   (if (clojure.string/blank? value)
-    (swap! state assoc error-key "Field is required")
+    (swap! state assoc error-key "This field is required")
     (swap! state assoc error-key nil)))
+
+(defn on-text-change [state key error-key value]
+  (swap! state assoc error-key nil key value))
 
 ;; name must match local component state key
 (defn text-input-with-label
@@ -24,7 +27,7 @@
                     :name name
                     :value (when val val)
                     :on-blur #(check-for-valid-content state error-key (get-value %))
-                    :on-change #(swap! state assoc key (get-value %))}]
+                    :on-change #(on-text-change state key error-key (get-value %))}]
      (when error-val
        [:div.inline-error error-val])]))
 

--- a/src/cljs/wombats_web_client/utils/forms.cljs
+++ b/src/cljs/wombats_web_client/utils/forms.cljs
@@ -2,16 +2,31 @@
   (:require [re-frame.core :as re-frame]))
 
 
+(defn get-value [element]
+  (-> element .-target .-value))
+
+(defn check-for-valid-content [state error-key value]
+  (if (clojure.string/blank? value)
+    (swap! state assoc error-key "Field is required")
+    (swap! state assoc error-key nil)))
+
 ;; name must match local component state key
 (defn text-input-with-label
   [{:keys [name label state]}]
-  (let [val (get @state (keyword name))]
+  (let [key (keyword name)
+        error-key (keyword (str name "-error"))
+        val (get @state key)
+        error-val (get @state error-key)]
     [:div.text-input-wrapper
      [:label.label {:for name} label]
-     [:input.input {:type "text"
+     [:input.input {:class (when error-val "field-error")
+                    :type "text"
                     :name name
                     :value (when val val)
-                    :on-change #(swap! state assoc (keyword name) (-> % .-target .-value))}]]))
+                    :on-blur #(check-for-valid-content state error-key (get-value %))
+                    :on-change #(swap! state assoc key (get-value %))}]
+     (when error-val
+       [:div.inline-error error-val])]))
 
 (defn cancel-modal-input []
   [:input.modal-button {:type "button"

--- a/src/cljs/wombats_web_client/utils/forms.cljs
+++ b/src/cljs/wombats_web_client/utils/forms.cljs
@@ -12,7 +12,7 @@
 
 ;; name must match local component state key
 (defn text-input-with-label
-  [{:keys [name label state]}]
+  [{:keys [name label state is-password]}]
   (let [key (keyword name)
         error-key (keyword (str name "-error"))
         val (get @state key)
@@ -20,7 +20,7 @@
     [:div.text-input-wrapper
      [:label.label {:for name} label]
      [:input.input {:class (when error-val "field-error")
-                    :type "text"
+                    :type (if is-password "password" "text")
                     :name name
                     :value (when val val)
                     :on-blur #(check-for-valid-content state error-key (get-value %))


### PR DESCRIPTION
# PR for Issue #154.

## PR Status

**READY**

## Changes proposed in the pull request:
- Client side validation checks
- On blur validation and on submit (before submitting to server) validation
- **NOTE: This for sure needs refactoring. Any suggestions for simplifying the form validation or code in general would be super helpful**

## Not included 
- server side error formatting for general errors (game full vs. game has started)
- inline server side errors for password and wombat color (@oconn we need a password field-error tag in the api)
- [REFACTOR] select dropdown, form validation, form styles, on blur of select component should close dropdown

## Breaking changes?
- None 

## Screenshot of feature:
![image](https://cloud.githubusercontent.com/assets/16102717/23526206/40b31168-ff5f-11e6-9ad6-47068638c84b.png)

