### PR TITLE
Fix get all wombats method

### DIFF
--- a/src/cljs/wombats_web_client/events/user.cljs
+++ b/src/cljs/wombats_web_client/events/user.cljs
@@ -47,7 +47,8 @@
 
 (defn get-all-wombats []
   (let [wombats-ch (load-wombats (get-current-user-id))]
-    (re-frame/dispatch [:update-wombats (go (async/<! wombats-ch))])))
+    (go 
+      (re-frame/dispatch [:update-wombats (async/<! wombats-ch)]))))
 
 
 (defn post-new-wombat


### PR DESCRIPTION
# PR for Issue where all wombats return async object instead of [].

## PR Status

**READY**

## Changes proposed in the pull request:
- Go wrapper for accessing wombats

## Breaking changes?
- none
