### PR TITLE
Fixed timer to only rerender timer component when time is udpated

### DIFF
--- a/src/cljs/wombats_web_client/components/cards/game.cljs
+++ b/src/cljs/wombats_web_client/components/cards/game.cljs
@@ -53,7 +53,7 @@
      [:img.arena-preview-img {:src "/images/mini-arena.png"}]
      (when is-open
        [:div.countdown "Starts in "
-        [countdown-timer start-time]])
+        [countdown-timer start-time game-id]])
      (when is-joinable
        [join-button {:is-private is-private
                      :on-click (open-join-game-modal-fn game-id)}])]))

--- a/src/cljs/wombats_web_client/components/countdown_timer.cljs
+++ b/src/cljs/wombats_web_client/components/countdown_timer.cljs
@@ -89,7 +89,7 @@
 
       :reagent-render
       (fn []
-        ;; triggers a rerender for active timers, will not effect timers with no interval timer
+        ;; triggers a rerender for active timers, will not affect timers with no interval timer
         (:update-counter @cmpnt-state)
 
         [:span {:class-name "countdown-timer"}

--- a/src/cljs/wombats_web_client/components/countdown_timer.cljs
+++ b/src/cljs/wombats_web_client/components/countdown_timer.cljs
@@ -27,11 +27,22 @@
     (mod (t/in-millis (interval-from-now time))
          1000)))
 
+(defn- time-left?
+  [start-time]
+  (< 0 (seconds-until start-time)))
+
+(defn- clear-timers [cmpnt-state]
+  (let [{:keys [interval-fn timeout-fn]} @cmpnt-state]
+    (.clearTimeout js/window timeout-fn)
+    (.clearInterval js/window interval-fn))
+  (swap! cmpnt-state assoc :update-time-counter 0))
+
 (defn- format-time
-  [time]
+  [time cmpnt-state]
   (let [seconds-left (seconds-until time)]
-    (if (< seconds-left 0)
-      "0:00"
+    ;; if time is left and requires an active timer
+    (if (time-left? time)
+      ;; calculate format of time
       (let [seconds (mod seconds-left 60)
             seconds-formatted (if (< seconds 10)
                                 (str "0" seconds)
@@ -40,39 +51,46 @@
             hours (int (/ minutes 60))
             minutes-adjusted (- minutes (* hours 60))
             minutes-formatted (str (when (< minutes-adjusted 10) "0") minutes-adjusted)]
-        (str (when (> hours 0) (str hours ":")) minutes-formatted ":" seconds-formatted)))))
+        (str (when (> hours 0) (str hours ":")) minutes-formatted ":" seconds-formatted))
+
+      ;; set to 0 time and clear timer
+      (do
+        (clear-timers cmpnt-state)
+        "0:00"))))
 
 (defn countdown-timer
-  [start-time]
+  [start-time id]
+
   (let [cmpnt-state (reagent/atom {:interval-fn nil
-                                   :timeout-fn nil})
+                                   :timeout-fn nil
+                                   :update-time-counter 0})
         swap-interval-fn! (fn []
-                      (swap! cmpnt-state
-                             assoc
-                             :interval-fn
-                             (.setInterval js/window
-                                           #(reagent/force-update-all)
-                                           1000)))
+                            (swap! cmpnt-state
+                                   assoc
+                                   :interval-fn
+                                   (.setInterval js/window
+                                                 ;; update state to trigger rerender
+                                                 #(swap! cmpnt-state update-in [:update-time-counter] inc)
+                                                 1000)))
         swap-timeout-fn! (fn []
-                      (swap! cmpnt-state
-                             assoc
-                             :timeout-fn
-                             (.setTimeout js/window
-                                          swap-interval-fn!
-                                          ;; Give the browser some extra time to render the next second
-                                          (- (millis-until start-time) 100))))]
+                           (swap! cmpnt-state
+                                  assoc
+                                  :timeout-fn
+                                  (.setTimeout js/window
+                                               swap-interval-fn!
+                                               ;; Give the browser some extra time to render the next second
+                                               (- (millis-until start-time) 100))))]
     (reagent/create-class
      {:component-will-mount
       ;; Force timer to redraw every second, start interval when the countdown timer should switch
-      (swap-timeout-fn!)
+      #(swap-timeout-fn!)
 
-      :component-will-unmount
-      (fn []
-        (let [{:keys [interval-fn timeout-fn]} @cmpnt-state]
-          (.clearTimeout js/window timeout-fn)
-          (.clearInterval js/window interval-fn)))
+      :component-will-unmount #(clear-timers cmpnt-state)
 
       :reagent-render
       (fn []
+        ;; triggers a rerender for active timers, will not effect timers with no interval timer
+        (:update-counter @cmpnt-state)
+
         [:span {:class-name "countdown-timer"}
-         (format-time start-time)])})))
+         (format-time start-time cmpnt-state)])})))


### PR DESCRIPTION
# PR for Issue #232 .

## PR Status

**READY**

## Changes proposed in the pull request:
- Remove force-update-all which updated every component every second
- Add simple state increment/deref which will only be changed for active timers
- clean up timer intervals when timer runs out or on unmount

## Breaking changes?
- None :)