### PR TITLE
Fixed timer bug.

### DIFF
--- a/src/cljs/wombats_web_client/components/countdown_timer.cljs
+++ b/src/cljs/wombats_web_client/components/countdown_timer.cljs
@@ -53,13 +53,11 @@
             minutes-formatted (str (when (< minutes-adjusted 10) "0") minutes-adjusted)]
         (str (when (> hours 0) (str hours ":")) minutes-formatted ":" seconds-formatted))
 
-      ;; set to 0 time and clear timer
-      (do
-        (clear-timers cmpnt-state)
-        "0:00"))))
+      ;; set to 0 time
+      "0:00")))
 
 (defn countdown-timer
-  [start-time id]
+  [start-time]
 
   (let [cmpnt-state (reagent/atom {:interval-fn nil
                                    :timeout-fn nil
@@ -88,7 +86,7 @@
       :component-will-unmount #(clear-timers cmpnt-state)
 
       :reagent-render
-      (fn []
+      (fn [start-time]
         ;; triggers a rerender for active timers, will not affect timers with no interval timer
         (:update-counter @cmpnt-state)
 

--- a/src/cljs/wombats_web_client/components/countdown_timer.cljs
+++ b/src/cljs/wombats_web_client/components/countdown_timer.cljs
@@ -58,7 +58,7 @@
      {:reagent-render
       (fn [start-time]
         ;; Force timer to redraw every second
-        (if (time-left? start-time)
+        (when (time-left? start-time)
           (.setTimeout js/window
                        #(swap! cmpnt-state update-in [:update] not)
                        1000))


### PR DESCRIPTION
# PR for Countdown Issue.

## PR Status

**READY**

## Changes proposed in the pull request:
- Fix how props are passed to countdown-timer (so they update properly).
- Keep interval going (even when timer reaches 0) so that new props are auto updated.
  - Performance is still great now that we have the changes from @emilyseibert 
- **Edit** With the latest change, I get rid of intervals and just use timeouts (making it more performant).

## Breaking changes?
- None

@emilyseibert @oconn @dehli
