### PR TITLE
game_play countdown timer fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ CHANGELOG
     [Matt O'Connell][/oconn] API Issue #[326](https://github.com/willowtreeapps/wombats-api/issues/326)
 * Fixed game & game_play pages to reflect API changes
     [C.P. Dehli][/dehli] #[344](https://github.com/willowtreeapps/wombats-api/pull/344)
+* Fix countdown timer between rounds (regression from Game State Refactor)
+    [C.P. Dehli][/dehli]
 
 ## QA
 **Enhancements**

--- a/src/cljs/wombats_web_client/panels/game_play.cljs
+++ b/src/cljs/wombats_web_client/panels/game_play.cljs
@@ -105,7 +105,7 @@
          :pending-closed
          :active-intermission)
         [:span (str "ROUND " round-number " STARTS IN: ")
-         [countdown-timer round-start-time]]
+         [countdown-timer (or round-start-time start-time)]]
 
         :active
         (str "ROUND " round-number)


### PR DESCRIPTION
# PR for Fixing countdown timer in between rounds

## PR Status
**READY**

## Ready for PR?
- [X] I have updated the CHANGELOG with an entry including a description, a link to my profile, and a link to the issue ticket. This change is filed under an Enhancement or Bug Fix, is shown under the relevant release tag name, and is included in my PR branch.
- [X] I have run `lein run-lint` to check for linting errors.

## Changes Proposed:
- Look at `round-start-time` if the game has already started, otherwise look at `start-time`

## Breaking changes?
- No

@emilyseibert @oconn @dehli
