### PR TITLE
Sort players hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ CHANGELOG
     [C.P. Dehli][/dehli] #[344](https://github.com/willowtreeapps/wombats-api/pull/344)
 * Fix countdown timer between rounds (regression from Game State Refactor)
     [C.P. Dehli][/dehli]
+* Fix sorting order for storing players in db
+    [C.P. Dehli][/dehli] #[307](https://github.com/willowtreeapps/wombats-web-client/issues/307)
 
 ## Master
 **Enhancements**

--- a/src/cljs/wombats_web_client/utils/games.cljs
+++ b/src/cljs/wombats_web_client/utils/games.cljs
@@ -99,8 +99,8 @@
 
 (defn sort-players
   [players-map]
-  (sort #(compare (get-player-score %1)
-                  (get-player-score %2))
+  (sort #(compare (get-player-score %2)
+                  (get-player-score %1))
         (vals players-map)))
 
 (defn get-arena-from-game


### PR DESCRIPTION
# PR for #307.

## PR Status
**READY**

## Ready for PR?
- [X] I have updated the CHANGELOG with an entry including a description, a link to my profile, and a link to the issue ticket. This change is filed under an Enhancement or Bug Fix, is shown under the relevant release tag name, and is included in my PR branch.
- [X] I have run `lein run-lint` to check for linting errors.

## Changes Proposed:
- Sort players so that highest score is in db.

## Breaking changes?
- None

## Screenshot of feature:
![image](https://cloud.githubusercontent.com/assets/5856011/24154673/3e97b6d6-0e28-11e7-8bd2-a9edd4219295.png)

@emilyseibert @oconn @dehli
