### PR TITLE
Fixed bug where you couldn't join private games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ CHANGELOG
 * None
 
 **Bug Fixes**
-* None
+* Fixed issue where you couldn't join private games
+    [C.P. Dehli][/dehli] [#310](https://github.com/willowtreeapps/wombats-web-client/issues/310)
 
 ## QA (3.21.2017)
 **Enhancements**

--- a/src/cljs/wombats_web_client/components/modals/join_wombat_modal.cljs
+++ b/src/cljs/wombats_web_client/components/modals/join_wombat_modal.cljs
@@ -121,7 +121,7 @@
 (defn correct-privacy-settings [is-private password-error]
   (cond
    ;; if it's private and there's no error, can submit
-   is-private (false? password-error)
+   is-private (nil? password-error)
 
    ;; if the game isn't private, password state is irrelevant
    (not is-private) true))


### PR DESCRIPTION
# PR for #310.

## PR Status
**READY**

## Ready for PR?
- [X] I have updated the CHANGELOG with an entry including a description, a link to my profile, and a link to the issue ticket. This change is filed under an Enhancement or Bug Fix, is shown under the relevant release tag name, and is included in my PR branch.
- [X] I have run `lein run-lint` to check for linting errors.

## Changes Proposed:
- Check that `password-error` is nil (instead of false) so that you can join private games.

## Breaking changes?
- None

@emilyseibert @oconn @dehli
